### PR TITLE
Refs #10 - Use TBD as default title on talks and activites

### DIFF
--- a/content/sessions/activity_1.md
+++ b/content/sessions/activity_1.md
@@ -1,6 +1,6 @@
 ---
 key: activity_1
-title: 'Outdoor Activity 1'
+title: 'Outdoor Activity TBD'
 id: 0MXH99V8NY9xyeurYCmD
 format: conference
 tags: []
@@ -9,4 +9,4 @@ speakers:  []
 presentation: null
 draft: false
 ---
-Abstract...
+Activity details will be available soon.

--- a/content/sessions/activity_2.md
+++ b/content/sessions/activity_2.md
@@ -1,6 +1,6 @@
 ---
 key: activity_2
-title: 'Outdoor Activity 2'
+title: 'Outdoor Activity TBD'
 id: 0MXH99V8NY9xyeurYCrP
 format: conference
 tags: []
@@ -9,4 +9,4 @@ speakers:  []
 presentation: null
 draft: false
 ---
-Abstract...
+Activity details will be available soon.

--- a/content/sessions/activity_3.md
+++ b/content/sessions/activity_3.md
@@ -1,6 +1,6 @@
 ---
 key: activity_3
-title: 'Outdoor Activity 3'
+title: 'Outdoor Activity TBD'
 id: 0MXH99V8NY9xOeutYCmD
 format: conference
 tags: []
@@ -9,4 +9,4 @@ speakers:  []
 presentation: null
 draft: false
 ---
-Abstract...
+Activity details will be available soon.

--- a/content/sessions/activity_4.md
+++ b/content/sessions/activity_4.md
@@ -1,6 +1,6 @@
 ---
 key: activity_4
-title: 'Outdoor Activity 4'
+title: 'Outdoor Activity TBD'
 id: 0MXH93w8NY9xyeurYCrP
 format: conference
 tags: []
@@ -9,4 +9,4 @@ speakers:  []
 presentation: null
 draft: false
 ---
-Abstract...
+Activity details will be available soon.

--- a/content/sessions/talk_1.md
+++ b/content/sessions/talk_1.md
@@ -1,6 +1,6 @@
 ---
 key: talk_1
-title: 'Talk about Infrastructure'
+title: TBD
 id: 0MXH99V8NY9xyeurYCmA
 format: conference
 tags:
@@ -10,4 +10,4 @@ speakers:  []
 presentation: null
 draft: false
 ---
-Abstract...
+Abstract will be available soon.

--- a/content/sessions/talk_2.md
+++ b/content/sessions/talk_2.md
@@ -1,6 +1,6 @@
 ---
 key: talk_2
-title: 'Another talk about Infrastructure'
+title: TBD
 id: 0MXH99V8NY9xyeurYCmB
 format: conference
 tags:
@@ -10,4 +10,4 @@ speakers:  []
 presentation: null
 draft: false
 ---
-Abstract...
+Abstract will be available soon.

--- a/content/sessions/talk_3.md
+++ b/content/sessions/talk_3.md
@@ -1,6 +1,6 @@
 ---
 key: talk_3
-title: 'Talk about SRE methods'
+title: TBD
 id: 2S9XtGGq3ouHnkivEDKC
 language: English
 format: conference
@@ -11,4 +11,4 @@ speakers: []
 presentation: null
 draft: false
 ---
-Abstract...
+Abstract will be available soon.

--- a/content/sessions/talk_4.md
+++ b/content/sessions/talk_4.md
@@ -1,6 +1,6 @@
 ---
 key: talk_4
-title: 'Another talk about SRE methods'
+title: TBD
 id: 2S9XtGGq3ouHnkivEDKD
 language: English
 format: conference
@@ -11,4 +11,4 @@ speakers: []
 presentation: null
 draft: false
 ---
-Abstract...
+Abstract will be available soon.

--- a/content/sessions/talk_5.md
+++ b/content/sessions/talk_5.md
@@ -1,6 +1,6 @@
 ---
 key: talk_5
-title: 'Talk about Infrastructure'
+title: TBD
 id: 0MXH99ApNY9xyeurYCmA
 format: conference
 tags:
@@ -10,4 +10,4 @@ speakers:  []
 presentation: null
 draft: false
 ---
-Abstract...
+Abstract will be available soon.

--- a/content/sessions/talk_6.md
+++ b/content/sessions/talk_6.md
@@ -1,6 +1,6 @@
 ---
 key: talk_6
-title: 'Another talk about Infrastructure'
+title: TBD
 id: 0PAH99V8NY9xyeurYCmB
 format: conference
 tags:
@@ -10,4 +10,4 @@ speakers:  []
 presentation: null
 draft: false
 ---
-Abstract...
+Abstract will be available soon.

--- a/content/sessions/talk_7.md
+++ b/content/sessions/talk_7.md
@@ -1,6 +1,6 @@
 ---
 key: talk_7
-title: 'Talk about SRE methods'
+title: TBD
 id: 2S9QOaGq3ouHnkivEDKC
 language: English
 format: conference
@@ -11,4 +11,4 @@ speakers: []
 presentation: null
 draft: false
 ---
-Abstract...
+Abstract will be available soon.

--- a/content/sessions/talk_8.md
+++ b/content/sessions/talk_8.md
@@ -1,6 +1,6 @@
 ---
 key: talk_8
-title: 'Another talk about SRE methods'
+title: TBD
 id: 2S9XtGGq3QAoankivEDKD
 language: English
 format: conference
@@ -11,4 +11,4 @@ speakers: []
 presentation: null
 draft: false
 ---
-Abstract...
+Abstract will be available soon.


### PR DESCRIPTION
As suggested on https://github.com/sre-summercamp/sre-summercamp.github.io/issues/10#issuecomment-1200891423 these changes use TBD (to be defined) as the default title for talks and activities.