### PR TITLE
content: slot for lightning talks

### DIFF
--- a/content/sessions/lightning_talks_1.md
+++ b/content/sessions/lightning_talks_1.md
@@ -1,0 +1,15 @@
+---
+key: lightning_talks_1
+title: Lightning Talks
+level: tous
+format: quickie
+tags: ['lightning-talks']
+speakers: []
+draft: false
+---
+Une série de présentations spontanées de moins de 5 minutes avec de slides ou pas.
+
+* Cycle de release de Flatcar par **Mathieu Tortuyaux**
+* MEPIE: un framework DevOps est possible ! par **Guilhem Lettron**
+* Refactorisation Terraform par **Arthur Busser**
+* Mirabelle par **Mathieu Corbin**

--- a/data/categories.yml
+++ b/data/categories.yml
@@ -36,3 +36,5 @@
   name: Pause
 - key: round-table
   name: Table ronde
+- key: lightning-talks
+  name: "\U000026A1 Lightning Talks"

--- a/data/schedule.yml
+++ b/data/schedule.yml
@@ -47,7 +47,7 @@
         - slot: slot-3
           talk: risques-erreurs-et-expertise
         - slot: pause-3
-          talk: __pause
+          talk: lightning_talks_1
         - slot: office-hours
           talk: round_table_2
         - slot: lunch


### PR DESCRIPTION
As slots described on `data/slots.yml` need to be exactly the same for every conference day, I ended re-using a pause slot on day 2.